### PR TITLE
Add Rakefile and update CI/CD for can_emulator

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -1,10 +1,3 @@
-# This workflow uses actions that are not certified by GitHub.
-# They are provided by a third-party and are governed by
-# separate terms of service, privacy policy, and support
-# documentation.
-# This workflow will download a prebuilt Ruby version, install dependencies and run tests with Rake
-# For more information see: https://github.com/marketplace/actions/setup-ruby-jruby-and-truffleruby
-
 name: Ruby
 
 on:
@@ -18,21 +11,22 @@ permissions:
 
 jobs:
   test:
-
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        ruby-version: ['2.6', '2.7', '3.0']
-
     steps:
-    - uses: actions/checkout@v4
-    - name: Set up Ruby
-    # To automatically get bug fixes and new Ruby versions for ruby/setup-ruby,
-    # change this to (see https://github.com/ruby/setup-ruby#versioning):
-    # uses: ruby/setup-ruby@v1
-      uses: ruby/setup-ruby@55283cc23133118229fd3f97f9336ee23a179fcf # v1.146.0
-      with:
-        ruby-version: ${{ matrix.ruby-version }}
-        bundler-cache: true # runs 'bundle install' and caches installed gems automatically
-    - name: Run tests
-      run: bundle exec rake
+      - uses: actions/checkout@v4
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 3.3.5
+          bundler-cache: true  # Runs 'bundle install' and caches installed gems automatically
+
+      - name: Change to can_emulator directory
+        working-directory: canalyze/can_emulator
+        run: |
+          # Install dependencies
+          bundle install
+
+      - name: Run tests
+        working-directory: canalyze/can_emulator
+        run: bundle exec rake

--- a/can_emulator/Gemfile
+++ b/can_emulator/Gemfile
@@ -4,7 +4,10 @@ source 'https://rubygems.org'
 
 # gem "rails"
 
-gem 'rspec', '~> 3.13'
-gem 'simplecov', require: false, group: :test
-
 gem "ostruct", "~> 0.6.0"
+gem "rake", "~> 13.2"
+
+group :test do
+  gem 'rspec', '~> 3.13'
+  gem "simplecov", "~> 0.22.0"
+end

--- a/can_emulator/Gemfile.lock
+++ b/can_emulator/Gemfile.lock
@@ -4,6 +4,7 @@ GEM
     diff-lcs (1.5.1)
     docile (1.4.1)
     ostruct (0.6.0)
+    rake (13.2.1)
     rspec (3.13.0)
       rspec-core (~> 3.13.0)
       rspec-expectations (~> 3.13.0)
@@ -30,8 +31,9 @@ PLATFORMS
 
 DEPENDENCIES
   ostruct (~> 0.6.0)
+  rake (~> 13.2)
   rspec (~> 3.13)
-  simplecov
+  simplecov (~> 0.22.0)
 
 BUNDLED WITH
    2.5.22

--- a/can_emulator/Rakefile
+++ b/can_emulator/Rakefile
@@ -1,0 +1,8 @@
+# canalyze/can_emulator/Rakefile
+require 'rspec/core/rake_task'
+
+RSpec::Core::RakeTask.new(:spec) do |t|
+  t.pattern = 'spec/**/*_spec.rb'
+end
+
+task default: :spec


### PR DESCRIPTION
Created a Rakefile to manage tests in the can_emulator directory and updated the GitHub Actions workflow to run these tests using Rake. Modified the Gemfile to include necessary dependencies and grouped testing gems under the :test group.